### PR TITLE
Build cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: $(DEBUG_OBJS) $(TEST_OBJS)
 	bin/unittests
 	
 coverage: test ## Run code coverage
-	@gcov src/Expander.cpp src/main.cpp test/TestExpander.cpp -o $(DEBUG_DIR) 
+	@gcov -r src/Expander.cpp src/main.cpp test/TestExpander.cpp -o $(DEBUG_DIR) 
 	
 report: coverage ## Generate gcovr report
 	@mkdir gcovr-report 2> /dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ TEST_OBJS = $(addprefix $(TEST_DIR)/, $(TEST_FILES))
 CXXFLAGS +=  -c -Wall -Wextra -Isrc/
 
 
-.PHONY: .default clean build test all coverage report install debug
-.default: build
+.PHONY: .default clean release install debug test coverage report 
+.default: release
     
 $(RELEASE_DIR)/%.o: src/%.cpp
 	 @mkdir -p $(@D)
@@ -32,8 +32,8 @@ $(TEST_DIR)/%.o: test/%.cpp
 	g++ $(CXXFLAGS) -o $@ $<
 
 # Builds the release executable
-build: CXXFLAGS += -O3
-build: $(RELEASE_OBJS)
+release: CXXFLAGS += -O3
+release: $(RELEASE_OBJS)
 	-mkdir bin
 	g++ $(RELEASE_OBJS) -o bin/$(EXE_FILE)
 	

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SRC_FILES:= Expander.o
 MAIN_FILE:= main.o
 TEST_FILES:= TestExpander.o
 
+# Build directories - allows for separate release and debug executables
 DEBUG_DIR = build/debug
 RELEASE_DIR = build/release
 TEST_DIR = build/test
@@ -11,8 +12,6 @@ DEBUG_OBJS = $(addprefix $(DEBUG_DIR)/, $(SRC_FILES))
 DEBUG_MAIN_OBJ = $(addprefix $(DEBUG_DIR)/, $(MAIN_FILE))
 RELEASE_OBJS = $(addprefix $(RELEASE_DIR)/, $(SRC_FILES) $(MAIN_FILE) )
 TEST_OBJS = $(addprefix $(TEST_DIR)/, $(TEST_FILES))
-
-#TEST_FLAGS:= $(CXXFLAGS) -fPIC -fprofile-arcs -ftest-coverage -Lgcov
 
 CXXFLAGS +=  -c -Wall -Wextra -Isrc/
 
@@ -48,12 +47,13 @@ clean:
 	@find . -name "*.gcov" -delete
 	
 
-debug: CXXFLAGS += -DDEBUG -g -O0 -fPIC -fprofile-arcs -ftest-coverage -Lgcov
+# Builds with debug data and coverage enabled
+debug: CXXFLAGS += -DDEBUG -g -O0 -fPIC -fprofile-arcs -ftest-coverage
 debug: $(DEBUG_OBJS) $(DEBUG_MAIN_OBJ)
 	-@mkdir bin
-	g++ $(DEBUG_OBJS) $(DEBUG_MAIN_OBJ) -o bin/$(EXE_FILE)d
+	g++ $(DEBUG_OBJS) $(DEBUG_MAIN_OBJ) -Lgcov -fPIC -fprofile-arcs -ftest-coverage -o bin/$(EXE_FILE)d
 
-
+# Builds the test using the debug objects - debug data is useful when debugging failing unit tests
 test: CXXFLAGS += -DDEBUG -g -fPIC -fprofile-arcs -ftest-coverage 
 test: $(DEBUG_OBJS) $(TEST_OBJS)
 	-mkdir bin

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: $(DEBUG_OBJS) $(TEST_OBJS)
 	bin/unittests
 	
 coverage: test ## Run code coverage
-	@gcov -r src/Expander.cpp src/main.cpp test/TestExpander.cpp -o $(DEBUG_DIR) 
+	@gcov -r -v src/Expander.cpp src/main.cpp test/TestExpander.cpp -o $(DEBUG_DIR) -o $(TEST_DIR)
 	
 report: coverage ## Generate gcovr report
 	@mkdir gcovr-report 2> /dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,21 @@
 EXE_FILE:=patexp
-OBJECTS:= Expander.o main.o
+SRC_FILES:= Expander.o
+MAIN_FILE:= main.o
+TEST_FILES:= TestExpander.o
 
 DEBUG_DIR = build/debug
 RELEASE_DIR = build/release
+TEST_DIR = build/test
 
-DEBUG_OBJS = $(addprefix $(DEBUG_DIR)/, $(OBJECTS))
-RELEASE_OBJS = $(addprefix $(RELEASE_DIR)/, $(OBJECTS))
+DEBUG_OBJS = $(addprefix $(DEBUG_DIR)/, $(SRC_FILES))
+DEBUG_MAIN_OBJ = $(addprefix $(DEBUG_DIR)/, $(MAIN_FILE))
+RELEASE_OBJS = $(addprefix $(RELEASE_DIR)/, $(SRC_FILES) $(MAIN_FILE) )
+TEST_OBJS = $(addprefix $(TEST_DIR)/, $(TEST_FILES))
 
-TEST_FLAGS:= $(CXXFLAGS) -fPIC -fprofile-arcs -ftest-coverage -Lgcov
+#TEST_FLAGS:= $(CXXFLAGS) -fPIC -fprofile-arcs -ftest-coverage -Lgcov
 
-CXXFLAGS +=  -c -I./src -I/usr/include -Wall -Wextra -pthread
+CXXFLAGS +=  -c -Wall -Wextra -Isrc/
 
-TEST_OBJS:= test/TestExpander.o
 
 .PHONY: .default clean build test all coverage report install debug
 .default: build
@@ -24,8 +28,9 @@ $(DEBUG_DIR)/%.o: src/%.cpp
 	@mkdir -p $(@D)
 	g++ $(CXXFLAGS) -o $@ $<
 
-test/%.o: test/%.cpp
-	g++ $(FLAGS) $(TEST_FLAGS) $(CXXFLAGS) $< -o $@
+$(TEST_DIR)/%.o: test/%.cpp
+	@mkdir -p $(@D)
+	g++ $(CXXFLAGS) -o $@ $<
 
 # Builds the release executable
 build: CXXFLAGS += -O3
@@ -44,15 +49,15 @@ clean:
 	
 
 debug: CXXFLAGS += -DDEBUG -g -O0
-debug: $(DEBUG_OBJS) src/main.o
+debug: $(DEBUG_OBJS) $(DEBUG_MAIN_OBJ)
 	-@mkdir bin
-	g++ $(DEBUG_OBJS) -o bin/$(EXE_FILE)d
+	g++ $(DEBUG_OBJS) $(DEBUG_MAIN_OBJ) -o bin/$(EXE_FILE)d
 
 
-test: CXXFLAGS += -DDEBUG -g -fprofile-arcs -ftest-coverage
-test: $(OBJECTS) $(TEST_OBJS)
+test: CXXFLAGS += -DDEBUG -g
+test: $(DEBUG_OBJS) $(TEST_OBJS)
 	-mkdir bin
-	g++ $(TEST_FLAGS) $(OBJECTS) $(TEST_OBJS) -lgtest -Lgoogletest/build/lib -o bin/unittests
+	g++ $(DEBUG_OBJS) $(TEST_OBJS) -lgtest -Lgoogletest/build/lib -o bin/unittests
 	bin/unittests
 	
 coverage: ## Run code coverage

--- a/Makefile
+++ b/Makefile
@@ -48,20 +48,20 @@ clean:
 	@find . -name "*.gcov" -delete
 	
 
-debug: CXXFLAGS += -DDEBUG -g -O0
+debug: CXXFLAGS += -DDEBUG -g -O0 -fPIC -fprofile-arcs -ftest-coverage -Lgcov
 debug: $(DEBUG_OBJS) $(DEBUG_MAIN_OBJ)
 	-@mkdir bin
 	g++ $(DEBUG_OBJS) $(DEBUG_MAIN_OBJ) -o bin/$(EXE_FILE)d
 
 
-test: CXXFLAGS += -DDEBUG -g
+test: CXXFLAGS += -DDEBUG -g -fPIC -fprofile-arcs -ftest-coverage 
 test: $(DEBUG_OBJS) $(TEST_OBJS)
 	-mkdir bin
-	g++ $(DEBUG_OBJS) $(TEST_OBJS) -lgtest -Lgoogletest/build/lib -o bin/unittests
+	g++ $(DEBUG_OBJS) $(TEST_OBJS) -lgtest -Lgoogletest/build/lib -Lgcov -fPIC -fprofile-arcs -ftest-coverage  -o bin/unittests
 	bin/unittests
 	
-coverage: ## Run code coverage
-	@gcov src/Expander.cpp src/main.cpp test/TestExpander.cpp
+coverage: test ## Run code coverage
+	@gcov src/Expander.cpp src/main.cpp test/TestExpander.cpp -o $(DEBUG_DIR) 
 	
 report: coverage ## Generate gcovr report
 	@mkdir gcovr-report 2> /dev/null || true

--- a/test/TestExpander.cpp
+++ b/test/TestExpander.cpp
@@ -2,7 +2,7 @@
 // Unit tests for the Expander class
 //
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 #include "Expander.h"
 
 using namespace ::testing;


### PR DESCRIPTION
Cleans up the Makefile. Adds separate debug target. Fixes coverage report to not generate coverage for STL. 