### PR TITLE
Expansion problem

### DIFF
--- a/src/Expander.cpp
+++ b/src/Expander.cpp
@@ -69,7 +69,7 @@ void Expander::generate(const wstring &pattern)
 				//Just appending the constant character to all patterns
 				for (uint j = 0; j < currentItem; j++)
 				{
-					results[j] = results[j] + pattern[i];
+					results[j] = results[j] + expandedPattern[i];
 				}
 			}
 		}
@@ -116,7 +116,7 @@ uint Expander::getBlockElements(const wstring &pattern, uint &start,
 	uint currentIndx = start; //remember we are going from right to left
 
 	//Find the end of the block
-	while (currentIndx >= 0) //we are going backwards
+	while (currentIndx != 0) //we are going backwards
 	{
 		if (pattern[currentIndx] == groupBegin
 				|| pattern[currentIndx] == groupEnd)
@@ -316,6 +316,11 @@ bool Expander::validate(const wstring &pattern)
 		output << "Error: Unclosed group bracket" << endl;
 	}
 
+	if (loadQuotes %2 != 0)
+	{
+		output << "Error: Unclosed quote detected" << endl;
+	}
+
 	return ((loadQuotes % 2 == 0) && (loadBrackets % 2 == 0));
 }
 
@@ -325,8 +330,8 @@ void Expander::getCombinations(vector<wstring> &data,
 	vector<wstring> original = data;
 	vector<wstring> temp = data;
 
-	uint numNewElements = newElements.size();
-	uint numOrgElements = original.size();
+	auto numNewElements = newElements.size();
+	auto numOrgElements = original.size();
 
 	//Nothing to do, just return
 	if (numNewElements == 0)
@@ -342,15 +347,15 @@ void Expander::getCombinations(vector<wstring> &data,
 	else
 	{
 
-		for (int i = 0; i < numOrgElements; i++)
+		for (size_t i = 0; i < numOrgElements; i++)
 		{
 			data[i] = data[i] + newElements[0];
 		}
 	}
 
-	for (int i = 1; i < numNewElements; i++)
+	for (size_t i = 1; i < numNewElements; i++)
 	{
-		for (int j = 0; j < numOrgElements; j++)
+		for (size_t j = 0; j < numOrgElements; j++)
 		{
 			temp[j] = temp[j] + newElements[i];
 		}
@@ -389,7 +394,7 @@ void Expander::processGroup(const wstring &pattern, uint &i, uint &currentItem)
 		}
 		//do the actual combination
 		int indx = 0; //current block element
-		for (int k = 0; k < currentItem; k++)
+		for (uint k = 0; k < currentItem; k++)
 		{
 
 			if (k != 0 && k % nDataElements == 0)

--- a/src/Expander.cpp
+++ b/src/Expander.cpp
@@ -23,7 +23,6 @@ void Expander::generate(const wstring &pattern)
 		return;
 	}
 
-	uint currentItem = 0; //current pattern in the data array
 	//Increment when unescaped [ is reached, decrement when ]
 	uint load = 0;
 	bool escSeqReached = false;
@@ -58,16 +57,15 @@ void Expander::generate(const wstring &pattern)
 		//it is a part of the pattern
 		if (load == 0) //constant character - escape sequences here are disregarded
 		{
-			if (currentItem == 0) //data array is empty
+			if (results.size() == 0) //data array is empty
 			{
 				results.push_back(wstring(1, expandedPattern[i]));
-				currentItem++;
 			}
 			else //variations are present.
 			{
 				//add the constant character to all variations
 				//Just appending the constant character to all patterns
-				for (uint j = 0; j < currentItem; j++)
+				for (size_t j = 0; j < results.size(); j++)
 				{
 					results[j] = results[j] + expandedPattern[i];
 				}

--- a/test/TestExpander.cpp
+++ b/test/TestExpander.cpp
@@ -640,6 +640,30 @@ TEST_F(TestExpander, testGenerate_VariableBlock_EmbededVarBlock_Cyrilic)
 	EXPECT_EQ(data[8], L"3в");
 }
 
+TEST_F(TestExpander, testGenerate_VariableBlock_First)
+{
+
+	wstring pattern = L"[1-3]abc";
+	underTest.generate(pattern);
+	auto data = underTest.getData();
+	EXPECT_EQ(data.size(), 3);
+	EXPECT_EQ(data[0], L"1abc");
+	EXPECT_EQ(data[1], L"2abc");
+	EXPECT_EQ(data[2], L"3abc");
+}
+
+TEST_F(TestExpander, testGenerate_VariableBlock_Middle)
+{
+
+	wstring pattern = L"ab[1-3]cd";
+	underTest.generate(pattern);
+	auto data = underTest.getData();
+	EXPECT_EQ(data.size(), 3);
+	EXPECT_EQ(data[0], L"ab1cd");
+	EXPECT_EQ(data[1], L"ab2cd");
+	EXPECT_EQ(data[2], L"ab3cd");
+}
+
 int main(int argc, char **argv)
 {
 	::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
When the group is in the begging of the pattern, the static string that came after was not being added correctly.
This was due to indexing problem (the index was not being incremented).
Instead of using an index, I changed the code to just check the size of the vector and append the static string to all items.

I also added unit test to verify that the fix works.