### PR TITLE
Adds quotes handling

### DIFF
--- a/src/Expander.h
+++ b/src/Expander.h
@@ -123,7 +123,9 @@ private:
 	void processGroup(const std::wstring &pattern, uint &i, uint &currentItem);
 
 	bool getLoadBalance(const std::wstring &pattern);
-
+	void append(std::vector<std::wstring> &results,
+			const std::wstring &newData);
+	void appendGroup(bool &isFirstInGroup, const std::wstring &newData, std::vector<std::wstring> &partials, std::vector<std::wstring> &results);
 };
 
 } //end namespace

--- a/test/TestExpander.cpp
+++ b/test/TestExpander.cpp
@@ -707,6 +707,28 @@ TEST_F(TestExpander, testGenerate_Static_Range_End)
 	EXPECT_EQ(data[2], L"3a-c");
 }
 
+TEST_F(TestExpander, testGenerate_QuotedString_InGroup)
+{
+
+	wstring pattern = L"a[b\"123\"c]\"";
+	underTest.generate(pattern);
+	auto data = underTest.getData();
+	EXPECT_EQ(data.size(), 3);
+	EXPECT_EQ(data[0], L"ab");
+	EXPECT_EQ(data[1], L"a123");
+	EXPECT_EQ(data[2], L"ac");
+}
+
+TEST_F(TestExpander, testGenerate_QuotedString)
+{
+
+	wstring pattern = L"\"[a-c]\"";
+	underTest.generate(pattern);
+	auto data = underTest.getData();
+	EXPECT_EQ(data.size(), 1);
+	EXPECT_EQ(data[0], L"[a-c]");
+}
+
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Text surounded by quotes is now considered static. This means that ranges are not expanded and group and processed as simple strings (including the [ ]).
No need to escape reserved characters when they are surrounded by quotes.